### PR TITLE
Adjust PHPUnit Framework namespace for PHPUnit6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 sudo: false
 php:
-  - 5.6
   - 7.0
   - 7.1
   - 7.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,19 @@ branches:
     - master
 
 before_install:
-  - wget https://raw.githubusercontent.com/owncloud/administration/master/travis-ci/before_install.sh
-  - bash ./before_install.sh $APP $CORE_BRANCH $DB
-  - cd ../core
-  - php occ app:enable $APP
+  - cd ../
+  - git clone https://github.com/owncloud/core.git --recursive --depth 1 -b $CORE_BRANCH
+  - mv $APP core/apps/
+  - cd core
+  - composer install
 
 before_script:
+  # Setup MySQL if applicable
+  - if [[ "$DB" == 'mysql' ]]; then mysql -u root -e 'create database oc_autotest;'; fi
+  - if [[ "$DB" == 'mysql' ]]; then mysql -u root -e "CREATE USER 'oc_autotest'@'localhost' IDENTIFIED BY '';"; fi
+  - if [[ "$DB" == 'mysql' ]]; then mysql -u root -e "grant all on oc_autotest.* to 'oc_autotest'@'localhost';"; fi
+  - ./occ maintenance:install --database-name oc_autotest --database-user oc_autotest --admin-user admin --admin-pass admin --database $DB --database-pass=''
+  - php occ app:enable $APP
   - cd apps/$APP
 
 script:

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,7 +21,7 @@
 	<repository type="git">https://github.com/owncloud/files_paperhive.git</repository>
 	<ocsid>166000</ocsid>
 	<dependencies>
-		<owncloud min-version="10.0.0" max-version="10.0.99" />
+		<owncloud min-version="10" max-version="10" />
 	</dependencies>
 	<types>
 		<filesystem/>

--- a/tests/Controller/PaperHiveControllerTest.php
+++ b/tests/Controller/PaperHiveControllerTest.php
@@ -42,25 +42,25 @@ class PaperHiveControllerTest extends TestCase {
 	/** @var string */
 	protected $appName;
 
-	/** @var \OCP\IRequest | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IRequest | \PHPUnit\Framework\MockObject\MockObject */
 	protected $requestMock;
 
-	/** @var \OCP\Http\Client\IResponse | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\Http\Client\IResponse | \PHPUnit\Framework\MockObject\MockObject */
 	protected $responseMock;
 
-	/** @var \OCP\IL10N | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\IL10N | \PHPUnit\Framework\MockObject\MockObject */
 	private $l10nMock;
 
-	/** @var \OCP\ILogger | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\ILogger | \PHPUnit\Framework\MockObject\MockObject */
 	private $loggerMock;
 
-	/** @var \OC\Files\View | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject */
 	private $viewMock;
 
-	/** @var \OCP\Http\Client\IClient | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var \OCP\Http\Client\IClient | \PHPUnit\Framework\MockObject\MockObject */
 	private $clientMock;
 
-	/** @var PaperHiveMetadata | \PHPUnit_Framework_MockObject_MockObject */
+	/** @var PaperHiveMetadata | \PHPUnit\Framework\MockObject\MockObject */
 	private $metaMock;
 	
 	public function setUp() {

--- a/tests/HooksTest.php
+++ b/tests/HooksTest.php
@@ -61,14 +61,14 @@ class HooksTest extends TestCase {
 		$this->hooks = new Hooks($this->view, $this->metadata);
 	}
 
-	public function testData() {
+	public function deleteMetadataProvider() {
 		return array (
 			array([ "fileid" => "abcd" ], true),
 			array(null, false),
 		);
 	}
 	/**
-	 * @dataProvider testData
+	 * @dataProvider deleteMetadataProvider
 	 * @param array $fileInfo
 	 * @param bool $deleteExpected
 	 */

--- a/tests/HooksTest.php
+++ b/tests/HooksTest.php
@@ -38,12 +38,12 @@ use Test\TestCase;
 class HooksTest extends TestCase {
 
 	/**
-	 * @var PaperHiveMetadata | \PHPUnit_Framework_MockObject_MockObject
+	 * @var PaperHiveMetadata | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $metadata;
 
 	/**
-	 * @var View | \PHPUnit_Framework_MockObject_MockObject
+	 * @var View | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $view;
 

--- a/tests/PaperHiveMetadataTest.php
+++ b/tests/PaperHiveMetadataTest.php
@@ -41,12 +41,12 @@ class PaperHiveMetadataTest extends TestCase {
 	private $metadata;
 
 	/**
-	 * @var IDBConnection | \PHPUnit_Framework_MockObject_MockObject
+	 * @var IDBConnection | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $connection;
 
 	/**
-	 * @var ILogger | \PHPUnit_Framework_MockObject_MockObject
+	 * @var ILogger | \PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $logger;
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -11,7 +11,3 @@ require_once __DIR__.'/../../../lib/base.php';
 \OC::$loader->addValidRoot(OC::$SERVERROOT . '/tests');
 
 \OC_App::loadApp('files_paperhive');
-
-if(!class_exists('PHPUnit_Framework_TestCase')) {
-	require_once('PHPUnit/Autoload.php');
-}

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <phpunit bootstrap="bootstrap.php"
 		 verbose="true"
+		 failOnRisky="true"
+		 failOnWarning="true"
 		 timeoutForSmallTests="900"
 		 timeoutForMediumTests="900"
 		 timeoutForLargeTests="900"


### PR DESCRIPTION
1) Adjust PHPUnit Framework namespace for PHPUnit6 
2) Remove PHP 5.6 from test matrix - it is no longer supported
3) There were problems using the `composer` on Travis. We need to explicitly do `composer install`. So do not use `before_install.sh` any more - do the core git clone and ownCloud install more manually in `.travis.yml`
4) ownCloud core now has version 10.1 - adjust the min-max-version allowed to be any 10.*
5) enable phpunit to fail on risky tests and on warnings
6) fix the name of the `tests/HooksTest.php` data provider so it does not start with the work `test` (phpunit was running the data provider method as a test)
