### PR TITLE
Suppress PhanDeprecatedFunction for doctrine/dbal changes

### DIFF
--- a/lib/PaperHiveMetadata.php
+++ b/lib/PaperHiveMetadata.php
@@ -89,9 +89,11 @@ class PaperHiveMetadata {
 			->where($qb->expr()->eq('fileid', $qb->createNamedParameter($fileId)))
 			->execute();
 
+		/* @phan-suppress-next-line PhanDeprecatedFunction */
 		while ($row = $cursor->fetch()) {
 			return $row['bookid'];
 		}
+		/* @phan-suppress-next-line PhanDeprecatedFunction */
 		$cursor->closeCursor();
 
 		return null;


### PR DESCRIPTION
`doctrine/dbal` was updated yesterday in core https://github.com/owncloud/core/pull/38647

Some methods have been deprecated, and `phan` reports those and fails the CI.

Suppress the deprecation warnings for now.

I raised issue #42 to actually adjust the code "some time".